### PR TITLE
Add persistent table with cluster info

### DIFF
--- a/lua/modules/callable.lua
+++ b/lua/modules/callable.lua
@@ -46,24 +46,26 @@ end
 -- Run selection --
 -------------------
 
-function M.runSelection(opts)
+local function parseCommand(opts)
     local currentFile = vim.api.nvim_buf_get_name(0)
-    print('==================================')
-    print("Running file: " .. currentFile:match('.*/(%S*)'))
-    local echoCommand = "echo \"Profile: $DATABRICKS_CONFIG_PROFILE\" && echo \"ClusterID: $DATABRICKS_CLUSTER_ID\" && echo '==================================' && "
+    local echoCommand = [[echo "==================================" && echo "Running file: ]] .. currentFile:match('.*/(%S*)') .. [[" && echo "Profile: $DATABRICKS_CONFIG_PROFILE" && echo "ClusterID: $DATABRICKS_CLUSTER_ID" && echo "==================================" && ]]
     local command = echoCommand .. opts.python .. " " .. currentFile
-    if ClusterSelectionState.profile and ClusterSelectionState.clusterId then command = "export DATABRICKS_CONFIG_PROFILE=" .. ClusterSelectionState.profile .. " && export DATABRICKS_CLUSTER_ID=" .. ClusterSelectionState.clusterId .. " && " .. echoCommand .. opts.python .. " " .. currentFile
+    if ClusterSelectionState.profile and ClusterSelectionState.clusterId then
+        command = "export DATABRICKS_CONFIG_PROFILE="
+        .. ClusterSelectionState.profile
+        .. " && export DATABRICKS_CLUSTER_ID="
+        .. ClusterSelectionState.clusterId
+        .. " && " .. echoCommand .. opts.python .. " " .. currentFile
     else
         print("No cluster selected, using DEFAULT config from " .. opts.DBConfigFile)
     end
+    return command
+end
 
-    local result = vim.fn.system(command)
-    if vim.v.shell_error ~= 0 then
-        print("Error executing command: " .. result)
-    else
-        print(result)
-    end
+function M.runSelection(opts)
+    local command = parseCommand(opts)
 
+    vim.cmd('split | terminal ' .. command)
 end
 
 -------------

--- a/lua/modules/profiles.lua
+++ b/lua/modules/profiles.lua
@@ -47,7 +47,7 @@ local function listProfiles(file)
     local fileName = file or "~/.databrickscfg"
     local command = "grep '^\\[' " .. fileName .. " | sed 's/[][]//g'"
 
-    return utils.callAndPaseCommand(command)
+    return utils.callLines(command, nil)
 
 end
 

--- a/lua/modules/utils.lua
+++ b/lua/modules/utils.lua
@@ -24,25 +24,40 @@ function M.printTable(tbl, _msg)
     print(msg .. "{\n" .. prepareResult(tbl, "") .. "\n}")
 end
 
-function M.parseCommandReturnList(list)
-    local result = {}
-    local resultIteration = 0
-    for s in list:gmatch("[^\r\n]+") do
-        table.insert(result, s)
-        resultIteration = resultIteration + 1
-    end
-
-    return result
+function M.addTableKeys(table, keyNumber)
+        local newTable = {}
+        for _, v in ipairs(table) do
+            newTable[v[keyNumber]] = v
+        end
+        return newTable
 end
 
-function M.callAndPaseCommand(command)
-    local commandResult = vim.fn.system(command)
+function M.getClusterStateAndName(splitLines)
+    local transformed = {}
+    for _, v in pairs(splitLines) do
+        -- Concatenate the state and name with a space and add to the new table
+        table.insert(transformed, v[2] .. " " .. v[3])
+    end
+    return transformed
+end
+
+function M.callLines(command, seperator)
+    local lines = vim.fn.systemlist(command)
     if vim.v.shell_error ~= 0 then
         print("Error executing command: " .. command)
         return
     end
 
-    return M.parseCommandReturnList(commandResult)
+    if seperator then
+        local splitLines = {}
+        for _, line in ipairs(lines) do
+            table.insert(splitLines, vim.split(line, seperator))
+        end
+        return splitLines
+    end
+
+    return lines
+
 end
 
 function M.tableCopy(orig)

--- a/lua/modules/window.lua
+++ b/lua/modules/window.lua
@@ -88,19 +88,19 @@ function Window:getClusterName()
     return lineContent:match('%S+%s+(.*)')
 end
 
-
 function Window:getClusterId(clusterName)
-    -- Fetch the cluster id, for the given name
-    -- Note, don't take names with " or '
-    local command = "databricks --profile " .. self.name .. " clusters list --output JSON | jq '.[] | select(.cluster_name == \"" .. clusterName .. "\") | .cluster_id'"
-
-    local clusterId = vim.fn.system(command)
-    if vim.v.shell_error ~= 0 then
-        print("Error executing command: " .. command)
+    -- Look through clusterTable to find clusterName
+    local clusterId = nil
+    for k, v in pairs(self.clustersTable) do
+        if k == clusterName then
+            clusterId = v[1]
+            return clusterId
+        end
     end
-    -- Strip away newline
-    clusterId = clusterId:gsub('"', "")
-    clusterId = clusterId:gsub("\n", "")
+    if not clusterId then
+        print("Error, no cluster id found for " .. clusterName)
+    end
+
     return clusterId
 
 end


### PR DESCRIPTION
This enables us to not have to run another api call to get the cluster id but rather get that on the initial lookup

Also added in there some cleanup of `runSelection` command.