### PR TITLE
Cluster start and stop option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ vim.api.nvim_set_keymap('n', '<new_keymap>', ':DBPrintState')
 | Add graphical objects to indicate, e.g., selected cluster and its state | 🟨 |
 | Add file type check for how to run with `DBRun`, e.g., if `.py` use `python` | 🟨 |
 | Add a `y` key for yanking all relevant output from the `DBRun` output window | 🟨 |
+| Add a `h` key for `help`, in which we can see all the keymaps. The "list" of them is too long now | 🟨 |
 
 ## Known bugs
 

--- a/lua/modules/buffers.lua
+++ b/lua/modules/buffers.lua
@@ -52,7 +52,7 @@ end
 
 local Tab = {
     boarder = "---------------------------",
-    header = "[q] quit, [enter] select, [r/R] redraw/all, [h] left, [l] right",
+    header = "[q] quit, [enter] select, [s] start/stop, [r/R] redraw/all, [h] left, [l] right",
     columns = "Status    Cluster Name",
     headerLength = 3 + 1 -- Clusters start on +1 line
 }

--- a/lua/modules/window.lua
+++ b/lua/modules/window.lua
@@ -204,6 +204,18 @@ function ClusterWindow:clusterKeymaps()
         vim.api.nvim_del_augroup_by_id(self.augroup)
     end
 
+    function self:_resetWindow(full)
+        -- Get cluster info for the specific profile
+        if full then
+            DB_CLUSTERS_LIST = {}
+        else
+            self:getClusters(true)
+        end
+        self:_closeClusterWindow()
+        vim.cmd("DBOpen")
+    end
+
+
     vim.api.nvim_buf_set_keymap(self.buf, 'n', '<CR>', '', {
         noremap = true,
         silent = true,
@@ -221,10 +233,7 @@ function ClusterWindow:clusterKeymaps()
         noremap = true,
         silent = true,
         callback = function()
-            self:_closeClusterWindow()
-            -- Get cluster info for the specific profile
-            self:getClusters(true)
-            vim.cmd("DBOpen")
+            self:_resetWindow(false)
         end,
     })
 
@@ -233,10 +242,7 @@ function ClusterWindow:clusterKeymaps()
         noremap = true,
         silent = true,
         callback = function()
-            self:_closeClusterWindow()
-            -- Get cluster info for all the buffers
-            DB_CLUSTERS_LIST = {}
-            vim.cmd("DBOpen")
+            self:_resetWindow(true)
         end,
     })
 end

--- a/lua/modules/window.lua
+++ b/lua/modules/window.lua
@@ -209,8 +209,8 @@ function ClusterWindow:clusterKeymaps()
         silent = true,
         callback = function()
             ClusterSelectionState.profile = self.name
-            print("Picked cluster: " .. self:getClusterName())
             ClusterSelectionState.name = self:getClusterName()
+            print("Picked cluster: " .. ClusterSelectionState.name)
             self:_closeClusterWindow()
             ClusterSelectionState.clusterId = self:getClusterId(ClusterSelectionState.name)
         end,


### PR DESCRIPTION
This is a feature to easily and automatically allow us to start and stop a given cluster, right from within the `DBOpen` window. This allow us to choose to start a cluster when entering a file, rather then on the first trigger using `DBRun`, saving time on startup of cluster, and _money_ if stopping unnecessary running cluster(s).

It uses the `databricks` cli. 