### PR TITLE
Add error handling for failing api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  nvim-databricks (0.2.0-beta)
+  nvim-databricks
 </h1>
 <p align="center">
 A simple, minimalistic, easy plugin to work with Databricks & Pyspark locally
@@ -38,6 +38,7 @@ jobs-api-version = 2.1
 [other_profile]
 ...
 ```
+> **_NOTE:_** All profiles that are in this file, needs to have valid setups, otherwise the plugin won't work
 
 ## Installation
 
@@ -98,6 +99,8 @@ vim.api.nvim_set_keymap('n', '<new_keymap>', ':DBPrintState')
 | Add a `h` key for `help`, in which we can see all the keymaps. The "list" of them is too long now | 🟨 |
 
 ## Known bugs
+
+> **_NOTE:_** If the plugin don't work, it's important to first check that any potential `VPN`'s or `Databricks tokens` are setup correctly. This would most likely show with a message: `Error executing command: databricks --profile prod clusters list ... ` when running `DBOpen`. This error is due to a failing `Databricks API` call.
 
 | Bugs | Status | Solution |
 | --- | --- | --- |

--- a/lua/modules/utils.lua
+++ b/lua/modules/utils.lua
@@ -57,8 +57,14 @@ end
 
 function M.callLines(command, seperator)
     local lines = vim.fn.systemlist(command)
-    if vim.v.shell_error ~= 0 then
+    -- Databricks API returns a message starting with `Error:`, which is used
+    -- here for detecting a failed call. This is due to systemlist failing to
+    -- return non-zero shell_error when call fails. Unsure why this is
+    if vim.v.shell_error ~= 0 or lines[1]:match("^Error:") ~= nil then
         print("Error executing command: " .. command)
+        for _, line in ipairs(lines) do
+            print(line)
+        end
         return
     end
 


### PR DESCRIPTION
`systemlist` is failing to return a non-zero `shell_error` when `Databricks API` call fails. Hence we have added a string lookup for detecting error, to guide the user in what the problem is. The problem is almost always:
1. VPN not turned on
2. Databricks Token has expired/invalid