### PR TITLE
0.2.2 Add support for nvim-dap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ nvim-databricks example run output
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/phdah/nvim-databricks/blob/main/LICENSE)
 <!-- badges: end -->
 
+Plugin to `view`, `start`/`stop` and `pick` a Databricks cluster when working with spark locally through [databricks-connect](https://learn.microsoft.com/en-us/azure/databricks/dev-tools/databricks-connect/python/). Offers a custom `run output` window and support for picking cluster when debugging using [nvim-dap](https://github.com/mfussenegger/nvim-dap).
+
 ## Requirements
 
 - Neovim `0.9.2`
@@ -40,11 +42,19 @@ jobs-api-version = 2.1
 ```
 > **_NOTE:_** All profiles that are in this file, needs to have valid setups, otherwise the plugin won't work
 
+##### Support
+- [nvim-dap](https://github.com/mfussenegger/nvim-dap), setting picked `Databricks cluster` when running debugger
+
 ## Installation
 
-Use your favorite package manager, e.g., `packer`:
+Use your favorite package manager, e.g., `lazy`:
 ````lua
-use {'phdah/nvim-databricks'}
+{
+    'phdah/nvim-databricks',
+    dependencies = {
+        'mfussenegger/nvim-dap', -- Optional dependency
+    }
+}
 ````
 and in your `init.lua`, put
 ````lua
@@ -58,6 +68,7 @@ For adding config, add a setup input like
 require('nvim-databricks').setup({
     DBConfigFile = '~/.databrickscfg', -- Set path to Databricks connect config file
     python = 'python3.10', -- Set Python version for DBRun
+    dap = "true", -- Toggle to enable setting nvim-dap python environmental variables for cluster selection
 })
 ````
 > **_NOTE:_** The values above are the defaults, so if this is what you want, just leave the setup empty.

--- a/lua/modules/window.lua
+++ b/lua/modules/window.lua
@@ -172,6 +172,18 @@ function ClusterWindow:getClusterId(clusterName)
 
 end
 
+function ClusterWindow:setDapEnv()
+    local dap = require("dap")
+    dap.configurations.python = {
+        {
+            env = {
+                DATABRICKS_CONFIG_PROFILE = ClusterSelectionState.profile,
+                DATABRICKS_CLUSTER_ID = ClusterSelectionState.clusterId
+            },
+        }
+    }
+end
+
 function ClusterWindow:toggleClusterOnOff(clusterTable, onlyStart)
     local command
     if clusterTable[2] == "TERMINATED" then
@@ -251,6 +263,9 @@ function ClusterWindow:clusterKeymaps()
             self:_startStopCluster(true)
             self:_closeClusterWindow()
             ClusterSelectionState.clusterId = self:getClusterId(ClusterSelectionState.name)
+            if true then
+                self:setDapEnv()
+            end
         end,
     })
 

--- a/lua/modules/window.lua
+++ b/lua/modules/window.lua
@@ -174,14 +174,14 @@ end
 
 function ClusterWindow:setDapEnv()
     local dap = require("dap")
-    dap.configurations.python = {
-        {
-            env = {
+    if dap.configurations.python then
+        for i in pairs(dap.configurations.python) do
+            dap.configurations.python[i].env = {
                 DATABRICKS_CONFIG_PROFILE = ClusterSelectionState.profile,
                 DATABRICKS_CLUSTER_ID = ClusterSelectionState.clusterId
-            },
-        }
-    }
+            }
+        end
+    end
 end
 
 function ClusterWindow:toggleClusterOnOff(clusterTable, onlyStart)

--- a/lua/nvim-databricks.lua
+++ b/lua/nvim-databricks.lua
@@ -18,18 +18,22 @@ M.setup = function(userOpts)
     -- Set python version
     if opts.python == nil then opts.python = "python3.10" end
 
+    -- Set DAP option
+    if opts.dap == nil then opts.dap = "true" end
+
+
+    -------------------------------
+    -- Setup base configurations --
+    -------------------------------
+
     -- Cluster state icons
-    if opts.states == nil then opts.states = {
+    opts.states = {
         terminated = "         ",
         running = "         ",
         pending = "       ",
         resizing = " 󰩨        ",
         terminating = "      ",
-    } end
-
-    -------------------------------
-    -- Setup base configurations --
-    -------------------------------
+    }
 
     --[[
     Create the floating window


### PR DESCRIPTION
This PR adds the support and option to set the databricks cluster for [nvim-dap](https://github.com/mfussenegger/nvim-dap) using the feature of `env` in the `dap.configurations.python` table.