### PR TITLE
HOTFIX Remove spaces in default icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ nvim-databricks example run output
 <!-- badges: start -->
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/phdah/nvim-databricks/blob/main/LICENSE)
 <!-- badges: end -->
+> [!IMPORTANT]
+> This plugin is no longer maintained, in favor of my new plugin: [lazydbrix](https://github.com/phdah/lazydbrix), which solves the same problem, but, better.
 
 Plugin to `view`, `start`/`stop` and `pick` a Databricks cluster when working with spark locally through [databricks-connect](https://learn.microsoft.com/en-us/azure/databricks/dev-tools/databricks-connect/python/). Offers a custom `run output` window and support for picking cluster when debugging using [nvim-dap](https://github.com/mfussenegger/nvim-dap).
 

--- a/lua/nvim-databricks.lua
+++ b/lua/nvim-databricks.lua
@@ -30,10 +30,10 @@ M.setup = function(userOpts)
     opts.states = {
         terminated =    "         ",
         running =       "         ",
-        pending =       "       ",
+        pending =       "       ",
         resizing =      " 󰩨        ",
-        terminating =   "       ",
-        restarting =    "       ",
+        terminating =   "       ",
+        restarting =    "       ",
     }
 
     --[[


### PR DESCRIPTION
This is a result of poorly implemented design on the selection. So this fix is just temporary, as the entire "select -> read selection" needs to be re-implemented.